### PR TITLE
Nmap attack

### DIFF
--- a/gauntlt/attacks/nmap-http-brute-force.attack
+++ b/gauntlt/attacks/nmap-http-brute-force.attack
@@ -36,4 +36,3 @@ Feature: Will brute force <hostname> on <tcp_ping_ports> using nmap.lst
     Then the file "foo.xml" should contain XML:
       | css                                                          |
       | ports port[protocol="tcp"][portid="80"] state[state="open"]  |
-      

--- a/gauntlt/attacks/nmap-http-brute-force.attack
+++ b/gauntlt/attacks/nmap-http-brute-force.attack
@@ -1,0 +1,36 @@
+@slow
+
+Feature: Will brute force <hostname> on <tcp_ping_ports> using nmap.lst
+  Background:
+    Given "nmap" is installed
+    And the following profile:
+      | name           | value        |
+      | hostname       | httpbin.org  |
+      | path           | /basic-auth/user/passwd  |
+      | tcp_ping_ports | 80         |
+      | nscript		   | http-brute |
+
+  Scenario: Verify server is open on expected set of ports using the nmap fast flag
+    When I launch an "nmap" attack with:
+      """
+      nmap -F <hostname>
+      """
+    Then the output should match:
+      """
+      80/tcp\s+open
+      """
+
+  Scenario: Output to XML
+    When I launch an "nmap" attack with:
+      """
+      nmap --script http-brute -p 80  <hostname> -d --script-args http-brute.path=<path>,unpwdb.timelimit=20s -oX foo.xml
+      """
+      
+    Then the file "foo.xml" should contain:
+    """
+    <elem key="Statistics">Performed
+    """
+
+    Then the file "foo.xml" should contain XML:
+      | css                                                          |
+      | ports port[protocol="tcp"][portid="80"] state[state="open"]  |

--- a/gauntlt/attacks/nmap-http-brute-force.attack
+++ b/gauntlt/attacks/nmap-http-brute-force.attack
@@ -20,7 +20,9 @@ Feature: Will brute force <hostname> on <tcp_ping_ports> using nmap.lst
       80/tcp\s+open
       """
 
-  Scenario: Output to XML
+
+  Scenario: Run the brute forcer and export to foo.xml
+  #For some reason, gauntlt doesn't like when things last for over 30 seconds, so I had to add a time limit.
     When I launch an "nmap" attack with:
       """
       nmap --script http-brute -p 80  <hostname> -d --script-args http-brute.path=<path>,unpwdb.timelimit=20s -oX foo.xml

--- a/gauntlt/attacks/nmap-http-brute-force.attack
+++ b/gauntlt/attacks/nmap-http-brute-force.attack
@@ -8,7 +8,6 @@ Feature: Will brute force <hostname> on <tcp_ping_ports> using nmap.lst
       | hostname       | httpbin.org  |
       | path           | /basic-auth/user/passwd  |
       | tcp_ping_ports | 80         |
-      | nscript		   | http-brute |
 
   Scenario: Verify server is open on expected set of ports using the nmap fast flag
     When I launch an "nmap" attack with:

--- a/gauntlt/attacks/nmap-http-brute-force.attack
+++ b/gauntlt/attacks/nmap-http-brute-force.attack
@@ -36,3 +36,4 @@ Feature: Will brute force <hostname> on <tcp_ping_ports> using nmap.lst
     Then the file "foo.xml" should contain XML:
       | css                                                          |
       | ports port[protocol="tcp"][portid="80"] state[state="open"]  |
+      


### PR DESCRIPTION
Added a gauntlt attack that runs the http-brute nscript that comes packages with nmap. Found user/password combos are saved into tmp/foo.xml. The only issue is that gauntlt has some timeout set at 30 seconds so the brute forcer can only run for 30 seconds before it breaks. 
